### PR TITLE
✏️(frontend) remove MonComptePro refs

### DIFF
--- a/packages/email/src/components/ProConnectLogo.tsx
+++ b/packages/email/src/components/ProConnectLogo.tsx
@@ -3,7 +3,7 @@
 export function ProConnectLogo() {
   return (
     <img
-      src="https://app.moncomptepro.beta.gouv.fr/dist/mail-proconnect.png"
+      src="https://identite.proconnect.gouv.fr/dist/mail-proconnect.png"
       alt="ProConnect Logo"
       height={73}
       width={193}

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -176,7 +176,7 @@ export default function AppDetailPage({ app }: { app: OidcClient }) {
                 urls={data.redirect_uris}
                 onUpdate={(redirect_uris) => handleUpdate({ redirect_uris })}
                 title="Configuration des URLs"
-                description="Saisissez l&rsquo;url de la ou les pages sur lesquelles vous souhaitez utiliser le bouton de connexion MonComptePro"
+                description="Saisissez l&rsquo;url de la ou les pages sur lesquelles vous souhaitez utiliser le bouton de connexion ProConnect"
                 label="URL de la page de connexion :"
               />
             </div>


### PR DESCRIPTION
Remove reference to the previous name of the app.
