### PR TITLE
apps: correct the wording for the redirect URIs

### DIFF
--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -183,8 +183,8 @@ export default function AppDetailPage({ app }: { app: OidcClient }) {
               <ProviderUrl
                 urls={data.redirect_uris}
                 onUpdate={(redirect_uris) => handleUpdate({ redirect_uris })}
-                title="Configuration des URLs"
-                description="Saisissez l&rsquo;adresse des pages sur lesquelles vous souhaitez utiliser le bouton de connexion ProConnect."
+                title="Configuration des URLs de redirection"
+                description="Saisissez l&rsquo;adresse des pages sur lesquelles vos utilisateurs seront redirigés après leur authentification sur ProConnect."
                 label="URL de la page de connexion :"
               />
             </div>


### PR DESCRIPTION
La page de configuration n'utilise pas les bons termes pour indiquer le renseignement des URLs de retour OIDC (`redirect_uri`).

<img width="831" alt="Capture d’écran 2025-06-02 à 09 53 21" src="https://github.com/user-attachments/assets/7453a14d-f24d-4077-be24-0eff9fc054ad" />
