### PR TITLE
📝 Add a doc describing userinfo expected format from idps

### DIFF
--- a/src/layouts/docsNav.ts
+++ b/src/layouts/docsNav.ts
@@ -170,6 +170,12 @@ export const docTree: SideMenuProps.Item[] = [
               href: "/docs/fournisseur-identite/troubleshooting-fi",
             },
           },
+          {
+            text: "Format de l'userinfo",
+            linkProps: {
+              href: "/docs/fournisseur-identite/format-user-info",
+            },
+          },
         ],
       },
     ],

--- a/src/pages/docs/fournisseur-identite/format-user-info.md
+++ b/src/pages/docs/fournisseur-identite/format-user-info.md
@@ -1,0 +1,13 @@
+# Contrôle des identités retournés par les userinfos des FI
+
+Pour que ProConnect reconnaisse comme valide une identité, le FI doit retourner les champs obligatoires définis [ici](./configuration.md#configurer-les-scopes) en respectant les contraintes.
+
+## Siret
+
+Si un siret est fourni avec des espaces, nous supprimons les espaces. Si ce siret est reconnu comme incorrect, nous le remplaçons par le siret par défaut du FI. Ce siret par défaut est configuré dans ProConnect.
+
+## Numéro de téléphone
+
+Les numéros de téléphone sont optionnels. Cependant si un FI retourne un champ `phone_number` avec une chaîne de caractères vide ou qui contient plus de 256 caractères, l'identité sera considérée comme invalide et ProConnect retournera une erreur.
+
+Si l'identité contient un `phone_number` qui respecte la contrainte définie ci-dessus mais est reconnu comme incorrect par ProConnect, ProConnect retournera une identité sans numéro de téléphone mais sans erreur.

--- a/src/pages/docs/fournisseur-identite/index.mdx
+++ b/src/pages/docs/fournisseur-identite/index.mdx
@@ -46,4 +46,5 @@ Voici un résumé des étapes pour être Fournisseur d'Identité ProConnect :
 - [Quels changements dois-je effectuer pour passer d'AgentConnect à ProConnect ?](./changement-agentconnect-proconnect-fi.md)
 - [Qu'est-ce que la plateforme "Internet", la plateforme "RIE" et l'"Hybridge" ?](./plateformes_fi.md)
 - [Quels sont les certificats d'authentification ?](./certificats_fi.md)
+- [Quel est le format attendu et retourné par ProConnect pour le `userinfo` ?](./format-user-info.md)
 - [Glossaire](../ressources/glossaire.md)


### PR DESCRIPTION
Add a short explanation of the conditions under which the userinfo response from an identity provider is accepted, transformed, or rejected by ProConnect Fédération.

<img width="2355" height="1349" alt="Screenshot from 2025-08-29 01-46-48" src="https://github.com/user-attachments/assets/83dd2c53-5b74-4401-9063-c9e75b5625e4" />

